### PR TITLE
Hotfix/coverage break build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wizsolucoes/syz-analyzer",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wizsolucoes/syz-analyzer",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "",
   "main": "index.js",
   "bin": {

--- a/src/syz-analysis-publisher.js
+++ b/src/syz-analysis-publisher.js
@@ -28,7 +28,7 @@ exports.publish = function (
   componentsNotFoundList = componentsNotFound;
 
   if (!areAzureStorageParamsValid()) {
-    callBack();
+    callBack(analysisValue);
     return;
   }
 
@@ -73,7 +73,7 @@ function onAppEntityInserted(error, result, response) {
 function onAnalysisEntityInserted(error, result, response) {
   handleError(error)
   console.log('SUCCESS: Analysis results published.');
-  callerCallBack();
+  callerCallBack(analysisValue);
 }
 
 function handleError(error) {

--- a/src/syz-analyzer.js
+++ b/src/syz-analyzer.js
@@ -109,7 +109,7 @@ async function calculateCoverage(expectedComponents, srcPath)  {
   };
 }
 
-function onResultsPublished() {
+function onResultsPublished(coverage) {
   if (buildBreakerOptions.isOn) {
     buildBreaker.run(coverage, buildBreakerOptions.gateWay);
   } else {


### PR DESCRIPTION
Função 'onPublishedResults' utilizava a variável 'coverage', que não estava definida em seu escopo.
Agora, ao ser chamada, a função recebe como argumento a variável 'coverage'.